### PR TITLE
ci: Add example GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
+  workflow_dispatch:
+
+# Needed for micromamba pickup
+defaults:
+  run:
+    shell: bash -l {0}
+
+jobs:
+  test:
+
+    runs-on: ${{ matrix.os }}
+    # On push events run the CI only on main by default, but run on any branch if the commit message contains '[ci all]'
+    if: >-
+      github.event_name != 'push'
+      || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+      || (github.event_name == 'push' && github.ref != 'refs/heads/main' && contains(github.event.head_commit.message, '[ci all]'))
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11"]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Setup Micromamba environment
+      uses: mamba-org/provision-with-micromamba@v15
+      with:
+        environment-file: environment.yml
+        environment-name: ci
+        extra-specs: |
+          python=${{ matrix.python-version }}
+        channels: conda-forge
+
+    - name: List installed conda packages
+      run: |
+        micromamba list
+
+    - name: List installed Python packages
+      run: |
+        python -m pip list
+
+    - name: Run predictive check notebooks
+      run: |
+        cd PredictiveChecks
+        jupyter execute priors.ipynb
+        ls -lhtra

--- a/PredictiveChecks/priors.ipynb
+++ b/PredictiveChecks/priors.ipynb
@@ -254,6 +254,7 @@
     "\n",
     "plt.title(f'Predictive checks DisplacedLeptons')\n",
     "\n",
+    "plt.savefig(\"displaced_leptons_predicitive_check.png\")\n",
     "plt.show()"
    ]
   },
@@ -287,6 +288,7 @@
     "\n",
     "plt.title(f'Predictive checks for ttbar')\n",
     "\n",
+    "plt.savefig(\"ttbar_predicitive_check.png\")\n",
     "plt.show()"
    ]
   },


### PR DESCRIPTION
This PR adds a first example of a GitHub Actions workflow that can be used for automated testing. This should ideally be testing things discretely with unit tests, but that is a bit difficult to do without well defined Python modules that can be imported (so future work :+1:).

* Add GitHub Actions workflow that uses the `mamba-org/provision-with-micromamba` GitHub Action to setup the environment defined in `environment.yml` and then run then run the `PredecitveChecks` notebook as an example test using `jupyter execute`.
* To do a quick visual check that the notebook runs okay by checking for the existence of plots, add a `plt.savefig` before each `plt.show` in the notebook.